### PR TITLE
fix parsing error with \r

### DIFF
--- a/src/java/dive/src/main/java/marine/Instruction.java
+++ b/src/java/dive/src/main/java/marine/Instruction.java
@@ -11,6 +11,6 @@ public class Instruction {
 
     public static Instruction fromText(String text) {
         var split = text.split(" ");
-        return new Instruction(split[0], Integer.parseInt(split[1]));
+        return new Instruction(split[0], Integer.parseInt(split[1].trim()));
     }
 }


### PR DESCRIPTION
Running the submarine tests failed on my machine (Windows), the parsing of the Integer failed because there was still a "\r" at the end of the line. Trimming fixed the issue for me!